### PR TITLE
Adding topic contracts

### DIFF
--- a/src/Eshopworld.Core/Eshopworld.Core.csproj
+++ b/src/Eshopworld.Core/Eshopworld.Core.csproj
@@ -1,8 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
 
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
+    <PackageReleaseNotes>Added topic operations to messaging contracts</PackageReleaseNotes>
 
     <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyTitle>Eshopworld.Core .Net Standard 2.0</AssemblyTitle>
@@ -18,7 +19,6 @@
     <Product>Eshopworld.Core</Product>
     <Copyright>Copyright 2018</Copyright>
     <PackageTags>Eshopworld, Telemetry, Core</PackageTags>
-    <PackageReleaseNotes>Deployment context established</PackageReleaseNotes>
 
     <IncludeSource>True</IncludeSource>
     <DebugType>Full</DebugType>

--- a/src/Eshopworld.Core/IMessage.cs
+++ b/src/Eshopworld.Core/IMessage.cs
@@ -1,7 +1,0 @@
-﻿namespace Eshopworld.Core
-{
-    /// <summary>
-    /// Marks a class as a message to be serialized and deserialized from the body of a Service Bus message.
-    /// </summary>
-    public interface IMessage { }
-}

--- a/src/Eshopworld.Core/IMessenger.cs
+++ b/src/Eshopworld.Core/IMessenger.cs
@@ -42,7 +42,7 @@
         /// and we retain that lock until we finish handling the message.
         /// </summary>
         /// <param name="message">The message that we want to create the lock on.</param>
-        /// <returns>The async <see cref="Task"/> wrapper</returns>        Task Lock<T>(T message) where T : class;
+        /// <returns>The async <see cref="Task"/> wrapper</returns>
         Task Lock<T>(T message) where T : class;
 
         /// <summary>

--- a/src/Eshopworld.Core/IMessenger.cs
+++ b/src/Eshopworld.Core/IMessenger.cs
@@ -5,43 +5,77 @@
     using JetBrains.Annotations;
 
     /// <summary>
-    /// Contract that provides a simple way to send messages.
+    /// Contract that provides a simple way to send messages to queues.
     /// </summary>
     public interface ISendMessages : IDisposable
     {
         /// <summary>
-        /// Sends a message.
+        /// Sends a message onto a queue.
         /// </summary>
         /// <typeparam name="T">The type of the message that we are sending.</typeparam>
         /// <param name="message">The message that we are sending.</param>
-        Task Send<T>([NotNull] T message) where T : IMessage;
+        Task Send<T>([NotNull] T message) where T : class;
+    }
+
+    /// <summary>
+    /// Contract that provides a simple way to send events to topics.
+    /// </summary>
+    public interface IPublishEvents : IDisposable
+    {
+        /// <summary>
+        /// Sends an event onto a topic.
+        /// </summary>
+        /// <typeparam name="T">The type of the event that we are sending.</typeparam>
+        /// <param name="event">The event that we are sending.</param>
+        Task Publish<T>(T @event) where T : class;
+    }
+
+    public interface ICancelReceive
+    {
+        /// <summary>
+        /// Stops receiving a message or event type by disabling the read pooling on the a message queue or topic subscription.
+        /// </summary>
+        /// <typeparam name="T">The type of the message that we are cancelling the receive on.</typeparam>
+        void CancelReceive<T>() where T : class;
     }
 
     /// <summary>
     /// Contract that provides a simple way to send and receive messages through callbacks.
     /// </summary>
-    public interface IMessenger : ISendMessages
+    public interface IDoMessages : ISendMessages, ICancelReceive
     {
         /// <summary>
         /// Sets up a call back for receiving any message of type <typeparamref name="T"/>.
-        /// If you try to setup more then one callback to the same message type <typeparamref name="T"/> you'll get an <see cref="InvalidOperationException"/>.
+        /// If you try to setup more then one callback to the same message or event type <typeparamref name="T"/> you'll get an <see cref="InvalidOperationException"/>.
         /// </summary>
         /// <typeparam name="T">The type of the message that we are subscribing to receiving.</typeparam>
         /// <param name="callback">The <see cref="Action{T}"/> delegate that will be called for each message received.</param>
+        /// <param name="batchSize">The size of the batch when reading for a queue - used as the pre-fetch parameter of the message receiver.</param>
         /// <exception cref="InvalidOperationException">Thrown when you attempt to setup multiple callbacks against the same <typeparamref name="T"/> parameter.</exception>
-        void Receive<T>([NotNull] Action<T> callback) where T : IMessage;
+        void Receive<T>(Action<T> callback, int batchSize = 10) where T : class;
+    }
 
+    /// <summary>
+    /// Contract that provides a simple way to send and receive events through callbacks.
+    /// </summary>
+    public interface IDoPubSub : IPublishEvents, ICancelReceive
+    {
         /// <summary>
-        /// Stops receiving a message type by disabling the read pooling on the a message queue.
+        /// Sets up a call back for receiving any event of type <typeparamref name="T"/>.
+        /// If you try to setup more then one callback to the same message or event type <typeparamref name="T"/> you'll get an <see cref="InvalidOperationException"/>.
         /// </summary>
-        /// <typeparam name="T">The type of the message that we are cancelling the receive on.</typeparam>
-        void CancelReceive<T>() where T : IMessage;
+        /// <typeparam name="T">The type of the event that we are subscribing to receiving.</typeparam>
+        /// <param name="callback">The <see cref="Action{T}"/> delegate that will be called for each event received.</param>
+        /// <param name="subscriptionName">The name of the reliable subscription we're doing for this event type.</param>
+        /// <param name="batchSize">The size of the batch when reading for a topic subscription - used as the pre-fetch parameter of the message receiver</param>
+        /// <exception cref="InvalidOperationException">Thrown when you attempt to setup multiple callbacks against the same <typeparamref name="T"/> parameter.</exception>
+        Task Subscribe<T>(Action<T> callback, string subscriptionName, int batchSize = 10) where T : class;
     }
 
     /// <summary>
     /// Contract that exposes a reactive way to receive and send messages.
     /// </summary>
-    public interface IReactiveMessenger : ISendMessages
+    public interface IDoReactiveMessages : ISendMessages, ICancelReceive
     {
         /// <summary>
         /// Setups up the required receive pipeline for the given message type and returns a reactive
@@ -49,6 +83,36 @@
         /// </summary>
         /// <typeparam name="T">The type of the message we want the reactive pipeline for.</typeparam>
         /// <returns>The typed <see cref="IObservable{T}"/> that you can plug into.</returns>
-        IObservable<T> GetObservable<T>() where T : IMessage;
+        IObservable<T> GetMessageObservable<T>(int batchSize = 10) where T : class;
+    }
+
+    /// <summary>
+    /// Contract that exposes a reactive way to receive and send messages.
+    /// </summary>
+    public interface IDoReactiveEvents : ISendMessages, ICancelReceive
+    {
+        /// <summary>
+        /// Setups up the required receive pipeline for the given event type and returns a reactive
+        /// <see cref="IObservable{T}"/> that you can plug into.
+        /// </summary>
+        /// <typeparam name="T">The type of the event we want the reactive pipeline for.</typeparam>
+        /// <param name="subscriptionName">The name of the reliable subscription we're doing for this event type.</param>
+        /// <param name="batchSize">The size of the batch when reading for a topic subscription - used as the pre-fetch parameter of the message receiver</param>
+        /// <returns>The typed <see cref="IObservable{T}"/> that you can plug into.</returns>
+        Task<IObservable<T>> GetEventObservable<T>(string subscriptionName, int batchSize = 10) where T : class;
+    }
+
+    /// <summary>
+    /// Contract that exposes all messaging operations, both for queues and topics.
+    /// </summary>
+    public interface IDoFullMessaging : IDoMessages, IDoPubSub
+    {
+    }
+
+    /// <summary>
+    /// Contract that exposes all messaging operations, both for queues and topics, through reactive (Rx) receivers.
+    /// </summary>
+    public interface IDoFullReactiveMessaging : IDoReactiveMessages, IDoReactiveEvents
+    {
     }
 }

--- a/src/Eshopworld.Core/IMessenger.cs
+++ b/src/Eshopworld.Core/IMessenger.cs
@@ -30,6 +30,9 @@
         Task Publish<T>(T @event) where T : class;
     }
 
+    /// <summary>
+    /// Contract that provides operations to cancel the pooling of either queues or topic subscriptions for reading events and messages.
+    /// </summary>
     public interface ICancelReceive
     {
         /// <summary>

--- a/src/Eshopworld.Core/Messaging.dgml
+++ b/src/Eshopworld.Core/Messaging.dgml
@@ -1,0 +1,353 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<DirectedGraph DataVirtualized="True" Layout="Sugiyama" ZoomLevel="-1" xmlns="http://schemas.microsoft.com/vs/2009/dgml">
+  <Nodes>
+    <Node Id="(@1 @3 Type=ICancelReceive Member=(Name=CancelReceive @13))" Category="CodeSchema_Method" Bounds="-9.88934893925984,-147.405495337931,110.906666666667,25.96" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsGeneric="True" CodeSchemaProperty_IsPublic="True" CodeSchemaProperty_IsVirtual="True" DelayedCrossGroupLinksState="Fetched" Label="CancelReceive" />
+    <Node Id="(@1 @3 Type=IDoMessages Member=(Name=Receive @13 OverloadingParameters=[(@14 Namespace=System Type=(Name=Action @13 GenericArguments=[(ParameterIdentifier=0)])),@15]))" Category="CodeSchema_Method" Bounds="195.078484753603,84.6210598462029,75.8533333333334,25.96" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsGeneric="True" CodeSchemaProperty_IsPublic="True" CodeSchemaProperty_IsVirtual="True" DelayedCrossGroupLinksState="Fetched" Label="Receive" />
+    <Node Id="(@1 @3 Type=IDoPubSub Member=(Name=Subscribe @13 OverloadingParameters=[(@14 Namespace=System Type=(Name=Action @13 GenericArguments=[(ParameterIdentifier=0)])),(@14 Namespace=System Type=String),@15]))" Category="CodeSchema_Method" Bounds="290.71525142027,-39.3789401537969,87.2633333333333,25.96" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsGeneric="True" CodeSchemaProperty_IsPublic="True" CodeSchemaProperty_IsVirtual="True" DelayedCrossGroupLinksState="Fetched" Label="Subscribe" />
+    <Node Id="(@1 @3 Type=IDoReactiveEvents Member=(Name=GetEventObservable @13 OverloadingParameters=[(@14 Namespace=System Type=String),@15]))" Category="CodeSchema_Method" Bounds="-345.965060119629,-28.8590509857178,143.26,25.96" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsGeneric="True" CodeSchemaProperty_IsPublic="True" CodeSchemaProperty_IsVirtual="True" DelayedCrossGroupLinksState="Fetched" Label="GetEventObservable" />
+    <Node Id="(@1 @3 Type=IDoReactiveMessages Member=(Name=GetMessageObservable @13 OverloadingParameters=[@15]))" Category="CodeSchema_Method" Bounds="-225.965423762004,87.1012490142823,161,25.96" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsGeneric="True" CodeSchemaProperty_IsPublic="True" CodeSchemaProperty_IsVirtual="True" DelayedCrossGroupLinksState="Fetched" Label="GetMessageObservable" />
+    <Node Id="(@1 @3 Type=IPublishEvents Member=(Name=Publish @13 OverloadingParameters=[(ParameterIdentifier=0)]))" Category="CodeSchema_Method" Bounds="16.1529095713297,84.5151057434082,74.26,25.96" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsGeneric="True" CodeSchemaProperty_IsPublic="True" CodeSchemaProperty_IsVirtual="True" DelayedCrossGroupLinksState="Fetched" Label="Publish" />
+    <Node Id="(@1 @3 Type=ISendMessages Member=(Name=Send @13 OverloadingParameters=[(ParameterIdentifier=0)]))" Category="CodeSchema_Method" Bounds="18.7812430826823,-31.4451953379313,62.5066666666667,25.96" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsGeneric="True" CodeSchemaProperty_IsPublic="True" CodeSchemaProperty_IsVirtual="True" DelayedCrossGroupLinksState="Fetched" Label="Send" />
+    <Node Id="(@1 @3)" Category="CodeSchema_Namespace" Bounds="-578.567234879052,-424.033992012532,146.396666666667,25.087552" DelayedChildNodesState="Incomplete" DelayedCrossGroupLinksState="Fetched" Group="Collapsed" Label="Eshopworld‎.Core" UseManualLocation="True" />
+    <Node Id="@10" Category="CodeSchema_Interface" Bounds="-245.965423762004,47.1011490142823,201,85.9602" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsPublic="True" CommonLabel="IDoReactiveMessages" DelayedChildNodesState="Fetched" DelayedCrossGroupLinksState="Fetched" FetchedChildrenCount="1" Group="Expanded" Icon="CodeSchema_Interface" Label="IDoReactiveMessages" SourceLocation="(Assembly=file:///C:/evo/core/src/Eshopworld.Core/IMessenger.cs StartLineNumber=77 StartCharacterOffset=21 EndLineNumber=77 EndCharacterOffset=40)" UseManualLocation="True" />
+    <Node Id="@11" Category="CodeSchema_Interface" Bounds="-14.9654237620036,44.5150057434082,136.496666666667,85.9602" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsPublic="True" CommonLabel="IPublishEvents" DelayedChildNodesState="Fetched" DelayedCrossGroupLinksState="Fetched" FetchedChildrenCount="1" Group="Expanded" Icon="CodeSchema_Interface" Label="IPublishEvents" SourceLocation="(Assembly=file:///C:/evo/core/src/Eshopworld.Core/IMessenger.cs StartLineNumber=22 StartCharacterOffset=21 EndLineNumber=22 EndCharacterOffset=35)" UseManualLocation="True" />
+    <Node Id="@12" Category="CodeSchema_Interface" Bounds="-21.207090250651,-71.4452953379313,142.483333333333,85.9602" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsPublic="True" CommonLabel="ISendMessages" DelayedChildNodesState="Fetched" DelayedCrossGroupLinksState="Fetched" FetchedChildrenCount="1" Group="Expanded" Icon="CodeSchema_Interface" Label="ISendMessages" SourceLocation="(Assembly=file:///C:/evo/core/src/Eshopworld.Core/IMessenger.cs StartLineNumber=9 StartCharacterOffset=21 EndLineNumber=9 EndCharacterOffset=34)" UseManualLocation="True" />
+    <Node Id="@2" Category="CodeSchema_Assembly" AssemblyTimestamp="09/12/2018 10:44:54" Bounds="-15.8196303990517,-305.024776127732,164.901457706667,25.0691202304" CodeSchemaProperty_StrongName="Eshopworld.Core, Version=1.0.3.0, Culture=neutral, PublicKeyToken=null" DelayedChildNodesState="Incomplete" DelayedCrossGroupLinksState="Fetched" FilePath="$(f508f5cc-79f8-4487-8124-4f3c925f5658.OutputPath)" Group="Collapsed" Label="Eshopworld.Core.dll" UseManualLocation="True">
+      <Category Ref="FileSystem.Category.FileOfType.dll" />
+    </Node>
+    <Node Id="@4" Category="CodeSchema_Interface" Bounds="-29.8893489392598,-187.405595337931,150.906666666667,85.9602" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsPublic="True" CommonLabel="ICancelReceive" DelayedChildNodesState="Fetched" DelayedCrossGroupLinksState="Fetched" FetchedChildrenCount="1" Group="Expanded" Icon="CodeSchema_Interface" Label="ICancelReceive" SourceLocation="(Assembly=file:///C:/evo/core/src/Eshopworld.Core/IMessenger.cs StartLineNumber=32 StartCharacterOffset=21 EndLineNumber=32 EndCharacterOffset=35)" UseManualLocation="True" />
+    <Node Id="@5" Category="CodeSchema_Interface" Bounds="152.233197913219,-178.379040153797,155.276666666667,44" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsPublic="True" CommonLabel="IDoFullMessaging" DelayedChildNodesState="Fetched" DelayedCrossGroupLinksState="Fetched" FetchedChildrenCount="0" Group="Expanded" Icon="CodeSchema_Interface" Label="IDoFullMessaging" SourceLocation="(Assembly=file:///C:/evo/core/src/Eshopworld.Core/IMessenger.cs StartLineNumber=107 StartCharacterOffset=21 EndLineNumber=107 EndCharacterOffset=37)" UseManualLocation="True" />
+    <Node Id="@6" Category="CodeSchema_Interface" Bounds="-261.793568753447,-180.379040153797,199.026666666667,44" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsPublic="True" CommonLabel="IDoFullReactiveMessaging" DelayedChildNodesState="Fetched" DelayedCrossGroupLinksState="Fetched" FetchedChildrenCount="0" Group="Expanded" Icon="CodeSchema_Interface" Label="IDoFullReactiveMessaging" SourceLocation="(Assembly=file:///C:/evo/core/src/Eshopworld.Core/IMessenger.cs StartLineNumber=114 StartCharacterOffset=21 EndLineNumber=114 EndCharacterOffset=45)" UseManualLocation="True" />
+    <Node Id="@7" Category="CodeSchema_Interface" Bounds="167.29515142027,44.6209598462029,131.42,85.9602" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsPublic="True" CommonLabel="IDoMessages" DelayedChildNodesState="Fetched" DelayedCrossGroupLinksState="Fetched" FetchedChildrenCount="1" Group="Expanded" Icon="CodeSchema_Interface" Label="IDoMessages" SourceLocation="(Assembly=file:///C:/evo/core/src/Eshopworld.Core/IMessenger.cs StartLineNumber=44 StartCharacterOffset=21 EndLineNumber=44 EndCharacterOffset=32)" UseManualLocation="True" />
+    <Node Id="@8" Category="CodeSchema_Interface" Bounds="270.71525142027,-79.379040153797,127.263333333333,85.9602" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsPublic="True" CommonLabel="IDoPubSub" DelayedChildNodesState="Fetched" DelayedCrossGroupLinksState="Fetched" FetchedChildrenCount="1" Group="Expanded" Icon="CodeSchema_Interface" Label="IDoPubSub" SourceLocation="(Assembly=file:///C:/evo/core/src/Eshopworld.Core/IMessenger.cs StartLineNumber=60 StartCharacterOffset=21 EndLineNumber=60 EndCharacterOffset=30)" UseManualLocation="True" />
+    <Node Id="@9" Category="CodeSchema_Interface" Bounds="-365.965060119629,-68.8591509857178,183.26,85.9602" CodeSchemaProperty_IsAbstract="True" CodeSchemaProperty_IsPublic="True" CommonLabel="IDoReactiveEvents" DelayedChildNodesState="Fetched" DelayedCrossGroupLinksState="Fetched" FetchedChildrenCount="1" Group="Expanded" Icon="CodeSchema_Interface" Label="IDoReactiveEvents" SourceLocation="(Assembly=file:///C:/evo/core/src/Eshopworld.Core/IMessenger.cs StartLineNumber=91 StartCharacterOffset=21 EndLineNumber=91 EndCharacterOffset=38)" UseManualLocation="True" />
+  </Nodes>
+  <Links>
+    <Link Source="@10" Target="(@1 @3 Type=IDoReactiveMessages Member=(Name=GetMessageObservable @13 OverloadingParameters=[@15]))" Category="Contains" FetchingParent="@10" />
+    <Link Source="@10" Target="@12" Category="Implements" Bounds="-74.5851067388605,18.4441587325753,47.2594655688683,28.656990281707" Weight="1" />
+    <Link Source="@10" Target="@4" Category="Implements" Bounds="-113.17448425293,-93.8501358032227,105.896656036377,140.951286315918" Weight="1" />
+    <Link Source="@11" Target="(@1 @3 Type=IPublishEvents Member=(Name=Publish @13 OverloadingParameters=[(ParameterIdentifier=0)]))" Category="Contains" FetchingParent="@11" />
+    <Link Source="@12" Target="(@1 @3 Type=ISendMessages Member=(Name=Send @13 OverloadingParameters=[(ParameterIdentifier=0)]))" Category="Contains" FetchingParent="@12" />
+    <Link Source="@2" Target="(@1 @3)" Category="Contains" FetchingParent="@2" />
+    <Link Source="@4" Target="(@1 @3 Type=ICancelReceive Member=(Name=CancelReceive @13))" Category="Contains" FetchingParent="@4" />
+    <Link Source="@5" Target="@11" Category="Implements" Bounds="113.886817932129,-134.379043579102,104.018928527832,172.665019989014" Weight="1" />
+    <Link Source="@5" Target="@12" Category="Implements" Bounds="118.202736773905,-134.379040153797,80.7384990697758,57.4274172425187" Weight="1" />
+    <Link Source="@5" Target="@4" Category="Implements" Bounds="130.497400295854,-151.343688575536,21.7357976173652,1.40970804161225" Weight="1" />
+    <Link Source="@5" Target="@7" Category="Implements" Bounds="230.154093815474,-134.379040153797,2.17702621873852,169.500783472543" Weight="1" />
+    <Link Source="@5" Target="@8" Category="Implements" Bounds="249.02852903609,-134.379040153797,41.6538723349043,47.8355325524123" Weight="1" />
+    <Link Source="@6" Target="@10" Category="Implements" Bounds="-160.791362257658,-136.379040153797,11.7757597448583,174.001869950775" Weight="1" />
+    <Link Source="@6" Target="@12" Category="Implements" Bounds="-126.326208603225,-136.379040153797,99.3129404893098,60.7688452226014" Weight="1" />
+    <Link Source="@6" Target="@4" Category="Implements" Bounds="-62.7669020867807,-151.698249330342,23.3988895792925,1.57087579668098" Weight="1" />
+    <Link Source="@6" Target="@9" Category="Implements" Bounds="-231.852405242535,-136.379040153797,50.9668389173582,60.2660851292238" Weight="1" />
+    <Link Source="@7" Target="(@1 @3 Type=IDoMessages Member=(Name=Receive @13 OverloadingParameters=[(@14 Namespace=System Type=(Name=Action @13 GenericArguments=[(ParameterIdentifier=0)])),@15]))" Category="Contains" FetchingParent="@7" />
+    <Link Source="@7" Target="@12" Category="Implements" Bounds="125.557766105079,19.442474004895,42.7723744591217,27.1323917995466" Weight="1" />
+    <Link Source="@7" Target="@4" Category="Implements" Bounds="111.761703491211,-95.5986328125,95.4334564208984,140.219593048096" Weight="1" />
+    <Link Source="@8" Target="(@1 @3 Type=IDoPubSub Member=(Name=Subscribe @13 OverloadingParameters=[(@14 Namespace=System Type=(Name=Action @13 GenericArguments=[(ParameterIdentifier=0)])),(@14 Namespace=System Type=String),@15]))" Category="Contains" FetchingParent="@8" />
+    <Link Source="@8" Target="@11" Category="Implements" Bounds="130.224158394318,-8.34986808600887,140.491093025952,61.92898912754" Weight="1" />
+    <Link Source="@8" Target="@4" Category="Implements" Bounds="129.915147101628,-112.871810996027,140.800104318642,52.6698376687539" Weight="1" />
+    <Link Source="@9" Target="(@1 @3 Type=IDoReactiveEvents Member=(Name=GetEventObservable @13 OverloadingParameters=[(@14 Namespace=System Type=String),@15]))" Category="Contains" FetchingParent="@9" />
+    <Link Source="@9" Target="@12" Category="Implements" Bounds="-182.705060119629,-27.8214580675485,151.99827179326,1.21185656075166" Weight="1" />
+    <Link Source="@9" Target="@4" Category="Implements" Bounds="-182.705060119629,-113.163324559317,143.907690479417,53.3285275897191" Weight="1" />
+  </Links>
+  <Categories>
+    <Category Id="CodeSchema_Assembly" Label="Assembly" BasedOn="File" CanBeDataDriven="True" DefaultAction="Microsoft.Contains" Icon="CodeSchema_Assembly" NavigationActionLabel="Assemblies" />
+    <Category Id="CodeSchema_Interface" Label="Interface" BasedOn="CodeSchema_Type" CanBeDataDriven="True" DefaultAction="Node:Both:CodeSchema_Member" Icon="CodeSchema_Interface" NavigationActionLabel="Interfaces" />
+    <Category Id="CodeSchema_Member" Label="Member" CanBeDataDriven="True" DefaultAction="Microsoft.Contains" Icon="CodeSchema_Field" NavigationActionLabel="Members" />
+    <Category Id="CodeSchema_Method" Label="Method" BasedOn="CodeSchema_Member" CanBeDataDriven="True" DefaultAction="Link:Forward:CodeSchema_Calls" Icon="CodeSchema_Method" NavigationActionLabel="Methods" />
+    <Category Id="CodeSchema_Namespace" Label="Namespace" CanBeDataDriven="True" DefaultAction="Node:Both:CodeSchema_Type" Icon="CodeSchema_Namespace" NavigationActionLabel="Namespaces" />
+    <Category Id="CodeSchema_Type" Label="Type" CanBeDataDriven="True" DefaultAction="Node:Both:CodeSchema_Member" Icon="CodeSchema_Class" NavigationActionLabel="Types" />
+    <Category Id="Contains" Label="Contains" Description="Whether the source of the link contains the target object" CanBeDataDriven="False" CanLinkedNodesBeDataDriven="True" IncomingActionLabel="Contained By" IsContainment="True" OutgoingActionLabel="Contains" />
+    <Category Id="File" Label="File" CanBeDataDriven="True" DefaultAction="Microsoft.Contains" Icon="File" NavigationActionLabel="Files" />
+    <Category Id="FileSystem.Category.FileOfType.dll" BasedOn="CodeSchema_Assembly" CanBeDataDriven="True" IsProviderRoot="False" />
+    <Category Id="Implements" Label="Implements" CanBeDataDriven="True" CanLinkedNodesBeDataDriven="True" IncomingActionLabel="Implemented by" OutgoingActionLabel="Implements" />
+  </Categories>
+  <Properties>
+    <Property Id="AssemblyTimestamp" DataType="System.DateTime" />
+    <Property Id="Bounds" DataType="System.Windows.Rect" />
+    <Property Id="CanBeDataDriven" Label="CanBeDataDriven" Description="CanBeDataDriven" DataType="System.Boolean" />
+    <Property Id="CanLinkedNodesBeDataDriven" Label="CanLinkedNodesBeDataDriven" Description="CanLinkedNodesBeDataDriven" DataType="System.Boolean" />
+    <Property Id="CodeSchemaProperty_IsAbstract" Label="Is Abstract" Description="Flag to indicate member is 'Abstract' does not provide a full implementation" DataType="System.Boolean" />
+    <Property Id="CodeSchemaProperty_IsGeneric" Label="Is Generic" Description="Flag to indicate the member is 'Generic'" DataType="System.Boolean" />
+    <Property Id="CodeSchemaProperty_IsPublic" Label="Is Public" Description="Flag to indicate the scope is Public" DataType="System.Boolean" />
+    <Property Id="CodeSchemaProperty_IsVirtual" Label="Is Virtual" Description="Flag to indicate the method can be overridden" DataType="System.Boolean" />
+    <Property Id="CodeSchemaProperty_StrongName" Label="StrongName" Description="StrongName" DataType="System.String" />
+    <Property Id="CommonLabel" DataType="System.String" />
+    <Property Id="DataVirtualized" Label="Data Virtualized" Description="If true, the graph can contain nodes and links that represent data for virtualized nodes/links (i.e. not actually created in the graph)." DataType="System.Boolean" />
+    <Property Id="DefaultAction" Label="DefaultAction" Description="DefaultAction" DataType="System.String" />
+    <Property Id="DelayedChildNodesState" Label="Delayed Child Nodes State" Description="Unspecified if the delayed child nodes state is not specified. NotFetched if the group contains child nodes that are not fetched into the graph yet. Fetched if the group has all its delayed child nodes already fetched." DataType="Microsoft.VisualStudio.GraphModel.DelayedDataState" />
+    <Property Id="DelayedCrossGroupLinksState" Label="Delayed Cross-Group Links State" Description="Unspecified if the delayed cross-group links state is not specified. NotFetched if delayed cross-group links on this node are not fetched into the graph yet. Fetched if all delayed cross-group links have already fetched." DataType="Microsoft.VisualStudio.GraphModel.DelayedDataState" />
+    <Property Id="Expression" DataType="System.String" />
+    <Property Id="FetchedChildrenCount" DataType="System.Int32" />
+    <Property Id="FetchingParent" DataType="Microsoft.VisualStudio.GraphModel.GraphNodeId" />
+    <Property Id="FilePath" Label="File Path" Description="File Path" DataType="System.String" />
+    <Property Id="Group" Label="Group" Description="Display the node as a group" DataType="Microsoft.VisualStudio.GraphModel.GraphGroupStyle" />
+    <Property Id="GroupLabel" DataType="System.String" />
+    <Property Id="Icon" Label="Icon" Description="Icon" DataType="System.String" />
+    <Property Id="IncomingActionLabel" Label="IncomingActionLabel" Description="IncomingActionLabel" DataType="System.String" />
+    <Property Id="IsContainment" DataType="System.Boolean" />
+    <Property Id="IsEnabled" DataType="System.Boolean" />
+    <Property Id="IsProviderRoot" Label="IsProviderRoot" Description="IsProviderRoot" DataType="System.Boolean" />
+    <Property Id="Label" Label="Label" Description="Displayable label of an Annotatable object" DataType="System.String" />
+    <Property Id="Layout" DataType="System.String" />
+    <Property Id="NavigationActionLabel" Label="NavigationActionLabel" Description="NavigationActionLabel" DataType="System.String" />
+    <Property Id="OutgoingActionLabel" Label="OutgoingActionLabel" Description="OutgoingActionLabel" DataType="System.String" />
+    <Property Id="SourceLocation" Label="Start Line Number" DataType="Microsoft.VisualStudio.GraphModel.CodeSchema.SourceLocation" />
+    <Property Id="TargetType" DataType="System.Type" />
+    <Property Id="UseManualLocation" DataType="System.Boolean" />
+    <Property Id="Value" DataType="System.String" />
+    <Property Id="ValueLabel" DataType="System.String" />
+    <Property Id="Visibility" Label="Visibility" Description="Defines whether a node in the graph is visible or not" DataType="System.Windows.Visibility" />
+    <Property Id="Weight" Label="Weight" Description="Weight" DataType="System.Double" />
+    <Property Id="ZoomLevel" DataType="System.String" />
+  </Properties>
+  <QualifiedNames>
+    <Name Id="Assembly" Label="Assembly" ValueType="Uri" />
+    <Name Id="GenericArguments" Label="Generic Arguments" ValueType="Microsoft.VisualStudio.GraphModel.GraphNodeIdCollection" />
+    <Name Id="GenericParameterCount" Label="Generic Parameter Count" ValueType="System.String" />
+    <Name Id="Member" Label="Member" ValueType="System.Object" />
+    <Name Id="Name" Label="Name" ValueType="System.String" />
+    <Name Id="Namespace" Label="Namespace" ValueType="System.String" />
+    <Name Id="OverloadingParameters" Label="Parameter" ValueType="Microsoft.VisualStudio.GraphModel.GraphNodeIdCollection" Formatter="NameValueNoEscape" />
+    <Name Id="ParameterIdentifier" Label="Parameter Identifier" ValueType="System.String" />
+    <Name Id="Type" Label="Type" ValueType="System.Object" />
+  </QualifiedNames>
+  <IdentifierAliases>
+    <Alias n="1" Uri="Assembly=$(f508f5cc-79f8-4487-8124-4f3c925f5658.OutputPathUri)" />
+    <Alias n="2" Id="(@1)" />
+    <Alias n="3" Id="Namespace=Eshopworld.Core" />
+    <Alias n="4" Id="(@1 @3 Type=ICancelReceive)" />
+    <Alias n="5" Id="(@1 @3 Type=IDoFullMessaging)" />
+    <Alias n="6" Id="(@1 @3 Type=IDoFullReactiveMessaging)" />
+    <Alias n="7" Id="(@1 @3 Type=IDoMessages)" />
+    <Alias n="8" Id="(@1 @3 Type=IDoPubSub)" />
+    <Alias n="9" Id="(@1 @3 Type=IDoReactiveEvents)" />
+    <Alias n="10" Id="(@1 @3 Type=IDoReactiveMessages)" />
+    <Alias n="11" Id="(@1 @3 Type=IPublishEvents)" />
+    <Alias n="12" Id="(@1 @3 Type=ISendMessages)" />
+    <Alias n="13" Id="GenericParameterCount=1" />
+    <Alias n="14" Uri="Assembly=$(FxUri)/netstandard.dll" />
+    <Alias n="15" Id="(@14 Namespace=System Type=Int32)" />
+  </IdentifierAliases>
+  <Styles>
+    <Style TargetType="Node" GroupLabel="Results" ValueLabel="True">
+      <Condition Expression="HasCategory('QueryResult')" />
+      <Setter Property="Background" Value="#FFBCFFBE" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Test Project" ValueLabel="Test Project">
+      <Condition Expression="HasCategory('CodeMap_TestProject')" />
+      <Setter Property="Icon" Value="CodeMap_TestProject" />
+      <Setter Property="Background" Value="#FF307A69" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Web Project" ValueLabel="Web Project">
+      <Condition Expression="HasCategory('CodeMap_WebProject')" />
+      <Setter Property="Icon" Value="CodeMap_WebProject" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Windows Store Project" ValueLabel="Windows Store Project">
+      <Condition Expression="HasCategory('CodeMap_WindowsStoreProject')" />
+      <Setter Property="Icon" Value="CodeMap_WindowsStoreProject" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Phone Project" ValueLabel="Phone Project">
+      <Condition Expression="HasCategory('CodeMap_PhoneProject')" />
+      <Setter Property="Icon" Value="CodeMap_PhoneProject" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Portable Library" ValueLabel="Portable Library">
+      <Condition Expression="HasCategory('CodeMap_PortableLibraryProject')" />
+      <Setter Property="Icon" Value="CodeMap_PortableLibraryProject" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="WPF Project" ValueLabel="WPF Project">
+      <Condition Expression="HasCategory('CodeMap_WpfProject')" />
+      <Setter Property="Icon" Value="CodeMap_WpfProject" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="VSIX Project" ValueLabel="VSIX Project">
+      <Condition Expression="HasCategory('CodeMap_VsixProject')" />
+      <Setter Property="Icon" Value="CodeMap_VsixProject" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Modeling Project" ValueLabel="Modeling Project">
+      <Condition Expression="HasCategory('CodeMap_ModelingProject')" />
+      <Setter Property="Icon" Value="CodeMap_ModelingProject" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Assembly" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Assembly')" />
+      <Setter Property="Background" Value="#FF094167" />
+      <Setter Property="Stroke" Value="#FF094167" />
+      <Setter Property="Icon" Value="CodeSchema_Assembly" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Namespace" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Namespace')" />
+      <Setter Property="Background" Value="#FF0E619A" />
+      <Setter Property="Stroke" Value="#FF0E619A" />
+      <Setter Property="Icon" Value="CodeSchema_Namespace" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Interface" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Interface')" />
+      <Setter Property="Background" Value="#FF1382CE" />
+      <Setter Property="Stroke" Value="#FF1382CE" />
+      <Setter Property="Icon" Value="CodeSchema_Interface" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Struct" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Struct')" />
+      <Setter Property="Background" Value="#FF1382CE" />
+      <Setter Property="Stroke" Value="#FF1382CE" />
+      <Setter Property="Icon" Value="CodeSchema_Struct" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Enumeration" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Enum')" />
+      <Setter Property="Background" Value="#FF1382CE" />
+      <Setter Property="Stroke" Value="#FF1382CE" />
+      <Setter Property="Icon" Value="CodeSchema_Enum" />
+      <Setter Property="LayoutSettings" Value="List" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Delegate" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Delegate')" />
+      <Setter Property="Background" Value="#FF1382CE" />
+      <Setter Property="Stroke" Value="#FF1382CE" />
+      <Setter Property="Icon" Value="CodeSchema_Delegate" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Class" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Type')" />
+      <Setter Property="Background" Value="#FF0E70C0" />
+      <Setter Property="Stroke" Value="#FF0E70C0" />
+      <Setter Property="Icon" Value="CodeSchema_Class" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Property" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Property')" />
+      <Setter Property="Background" Value="#FFE0E0E0" />
+      <Setter Property="Stroke" Value="#FFE0E0E0" />
+      <Setter Property="Icon" Value="CodeSchema_Property" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Method" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Method') Or HasCategory('CodeSchema_CallStackUnresolvedMethod')" />
+      <Setter Property="Background" Value="#FFE0E0E0" />
+      <Setter Property="Stroke" Value="#FFE0E0E0" />
+      <Setter Property="Icon" Value="CodeSchema_Method" />
+      <Setter Property="LayoutSettings" Value="List" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Event" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Event')" />
+      <Setter Property="Background" Value="#FFE0E0E0" />
+      <Setter Property="Stroke" Value="#FFE0E0E0" />
+      <Setter Property="Icon" Value="CodeSchema_Event" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Field" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Field')" />
+      <Setter Property="Background" Value="#FFE0E0E0" />
+      <Setter Property="Stroke" Value="#FFE0E0E0" />
+      <Setter Property="Icon" Value="CodeSchema_Field" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Out Parameter" ValueLabel="Has category">
+      <Condition Expression="CodeSchemaProperty_IsOut = 'True'" />
+      <Setter Property="Icon" Value="CodeSchema_OutParameter" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Parameter" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_Parameter')" />
+      <Setter Property="Icon" Value="CodeSchema_Parameter" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Local Variable" ValueLabel="Has category">
+      <Condition Expression="HasCategory('CodeSchema_LocalExpression')" />
+      <Setter Property="Icon" Value="CodeSchema_LocalExpression" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Externals" ValueLabel="Has category">
+      <Condition Expression="HasCategory('Externals')" />
+      <Setter Property="Background" Value="#FF424242" />
+      <Setter Property="Stroke" Value="#FF424242" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Inherits From" ValueLabel="True">
+      <Condition Expression="HasCategory('InheritsFrom')" />
+      <Setter Property="Stroke" Value="#FF00A600" />
+      <Setter Property="StrokeDashArray" Value="2 0" />
+      <Setter Property="DrawArrow" Value="true" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Implements" ValueLabel="True">
+      <Condition Expression="HasCategory('Implements')" />
+      <Setter Property="Stroke" Value="#8000A600" />
+      <Setter Property="StrokeDashArray" Value="2 2" />
+      <Setter Property="DrawArrow" Value="true" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Calls" ValueLabel="True">
+      <Condition Expression="HasCategory('CodeSchema_Calls')" />
+      <Setter Property="Stroke" Value="#FFFF00FF" />
+      <Setter Property="StrokeDashArray" Value="2 0" />
+      <Setter Property="DrawArrow" Value="true" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Function Pointer" ValueLabel="True">
+      <Condition Expression="HasCategory('CodeSchema_FunctionPointer')" />
+      <Setter Property="Stroke" Value="#FFFF00FF" />
+      <Setter Property="StrokeDashArray" Value="2 2" />
+      <Setter Property="DrawArrow" Value="true" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Field Read" ValueLabel="True">
+      <Condition Expression="HasCategory('CodeSchema_FieldRead')" />
+      <Setter Property="Stroke" Value="#FF00AEEF" />
+      <Setter Property="StrokeDashArray" Value="2 2" />
+      <Setter Property="DrawArrow" Value="true" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Field Write" ValueLabel="True">
+      <Condition Expression="HasCategory('CodeSchema_FieldWrite')" />
+      <Setter Property="Stroke" Value="#FF00AEEF" />
+      <Setter Property="DrawArrow" Value="true" />
+      <Setter Property="IsHidden" Value="false" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Inherits From" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="HasCategory('InheritsFrom') And Target.HasCategory('CodeSchema_Class')" />
+      <Setter Property="TargetDecorator" Value="OpenArrow" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Implements" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="HasCategory('Implements') And Target.HasCategory('CodeSchema_Interface')" />
+      <Setter Property="TargetDecorator" Value="OpenArrow" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Comment Link" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="Source.HasCategory('Comment')" />
+      <Setter Property="Stroke" Value="#FFE5C365" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Cursor Location Changed" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="IsCursorLocation" />
+      <Setter Property="IndicatorWest" Value="WestIndicator" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Disabled Breakpoint Location Changed" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="DisabledBreakpointCount" />
+      <Setter Property="IndicatorWest" Value="WestIndicator" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Enabled Breakpoint Location Changed" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="EnabledBreakpointCount" />
+      <Setter Property="IndicatorWest" Value="WestIndicator" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Instruction Pointer Location Changed" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="IsInstructionPointerLocation" />
+      <Setter Property="IndicatorWest" Value="WestIndicator" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Current Callstack Changed" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="IsCurrentCallstackFrame" />
+      <Setter Property="IndicatorWest" Value="WestIndicator" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Return" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="HasCategory('CodeSchema_ReturnTypeLink')" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="References" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="HasCategory('References')" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Uses Attribute" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="HasCategory('CodeSchema_AttributeUse')" />
+    </Style>
+    <Style TargetType="Node" GroupLabel="Solution Folder" ValueLabel="True" Visibility="Hidden">
+      <Condition Expression="HasCategory('CodeMap_SolutionFolder')" />
+      <Setter Property="Background" Value="#FFDEBA83" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="Project Reference" ValueLabel="Project Reference">
+      <Condition Expression="HasCategory('CodeMap_ProjectReference')" />
+      <Setter Property="Stroke" Value="#9A9A9A" />
+      <Setter Property="StrokeDashArray" Value="2 2" />
+      <Setter Property="DrawArrow" Value="true" />
+    </Style>
+    <Style TargetType="Link" GroupLabel="External Reference" ValueLabel="External Reference">
+      <Condition Expression="HasCategory('CodeMap_ExternalReference')" />
+      <Setter Property="Stroke" Value="#9A9A9A" />
+      <Setter Property="StrokeDashArray" Value="2 2" />
+      <Setter Property="DrawArrow" Value="true" />
+    </Style>
+  </Styles>
+  <Paths>
+    <Path Id="f508f5cc-79f8-4487-8124-4f3c925f5658.OutputPath" Value="C:\evo\core\src\Eshopworld.Core\bin\Debug\netstandard2.0\Eshopworld.Core.dll" />
+    <Path Id="f508f5cc-79f8-4487-8124-4f3c925f5658.OutputPathUri" Value="file:///C:/evo/core/src/Eshopworld.Core/bin/Debug/netstandard2.0/Eshopworld.Core.dll" />
+    <Path Id="FxUri" Value="file:///C:/Windows/Microsoft.NET/Framework/v4.0.30319" />
+  </Paths>
+</DirectedGraph>


### PR DESCRIPTION
Refactored the messaging contracts to support topic operations and added two new ones that aggregate queues and topics, one for callbacks and one for Rx.

See this diagram:
![messaging_contracts](https://user-images.githubusercontent.com/2116066/45420826-23a83f80-b683-11e8-81fd-dbd6e194109a.png)
