### PR TITLE
DNS config cascade interface defined

### DIFF
--- a/src/Eshopworld.Core/Eshopworld.Core.csproj
+++ b/src/Eshopworld.Core/Eshopworld.Core.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
 
-    <Version>2.1.1</Version>
-    <PackageReleaseNotes>declare friendship to eshopworld.web (including tests)</PackageReleaseNotes>
+    <Version>2.1.2</Version>
+    <PackageReleaseNotes>add dns configuration cascade interface</PackageReleaseNotes>
 
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>

--- a/src/Eshopworld.Core/IDNSConfigurationCascade.cs
+++ b/src/Eshopworld.Core/IDNSConfigurationCascade.cs
@@ -1,0 +1,15 @@
+﻿namespace Eshopworld.Core
+{
+    /// <summary>
+    /// this interface defines evolution platform (V2) service (e.g. API) deployment cascade and possible routes to its instances
+    ///
+    /// Proxy (Service Fabric Reverse Proxy) -> Cluster (regional external load balancer) -> Global (FrontDoor)
+    /// </summary>
+    // ReSharper disable once InconsistentNaming
+    public interface IDNSConfigurationCascade
+    {
+        string Proxy { get; set; }
+        string Cluster { get; set; }
+        string Global { get; set; }
+    }
+}

--- a/src/Eshopworld.Core/IDNSConfigurationCascade.cs
+++ b/src/Eshopworld.Core/IDNSConfigurationCascade.cs
@@ -5,8 +5,7 @@
     ///
     /// Proxy (Service Fabric Reverse Proxy) -> Cluster (regional external load balancer) -> Global (FrontDoor)
     /// </summary>
-    // ReSharper disable once InconsistentNaming
-    public interface IDNSConfigurationCascade
+    public interface IDnsConfigurationCascade
     {
         string Proxy { get; set; }
         string Cluster { get; set; }


### PR DESCRIPTION
anyone having different naming suggestion?

note that the interface members are matching naming of configuration in KV - I chose not to rename these via e.g. JsonProperty attributes etc.