### PR TITLE
init

### DIFF
--- a/src/Eshopworld.Core/AnonymousTelemetryEvent.cs
+++ b/src/Eshopworld.Core/AnonymousTelemetryEvent.cs
@@ -1,8 +1,6 @@
 ﻿namespace Eshopworld.Core
 {
-    using System;
     using System.Collections.Generic;
-    using System.Linq;
     using JetBrains.Annotations;
     using Newtonsoft.Json;
 
@@ -38,24 +36,7 @@
         /// <returns>The converted <see cref="IDictionary{String, String}"/>.</returns>
         internal override IDictionary<string, string> ToStringDictionary()
         {
-            try
-            {
-                return JsonConvert.DeserializeObject<Dictionary<string, string>>(JsonConvert.SerializeObject(Payload))
-                                  .Union(base.ToStringDictionary())
-                                  .ToDictionary(k => k.Key, v => v.Value);
-            }
-            catch (Exception)
-            {
-                return JsonConvert.DeserializeObject<Dictionary<string, string>>(
-                                      JsonConvert.SerializeObject(Payload, new JsonSerializerSettings
-                                      {
-                                          ContractResolver = new NoReferencesJsonContractResolver(),
-                                          PreserveReferencesHandling = PreserveReferencesHandling.None,
-                                          ReferenceLoopHandling = ReferenceLoopHandling.Error
-                                      }))
-                                  .Union(base.ToStringDictionary())
-                                  .ToDictionary(k => k.Key, v => v.Value);
-            }
+            return ToUnionStringDictionary(Payload);
         }
     }
 }

--- a/src/Eshopworld.Core/BaseEvent.cs
+++ b/src/Eshopworld.Core/BaseEvent.cs
@@ -25,8 +25,18 @@
 
         internal  IDictionary<string, string> ToUnionStringDictionary(object adjunctObject)
         {
-            return ToStringDictionaryInner(this).Union(ToStringDictionaryInner(adjunctObject))
-                .ToDictionary(k => k.Key, v => v.Value);
+            IDictionary<string, string> adjunctDictionary = null;
+            try
+            {
+                adjunctDictionary = ToStringDictionaryInner(adjunctObject);
+            }
+            catch (Exception)
+            {
+                //soak
+            }
+            return adjunctDictionary!=null 
+                ? ToStringDictionaryInner(this).Union(ToStringDictionaryInner(adjunctObject)).ToDictionary(k => k.Key, v => v.Value) 
+                : ToStringDictionaryInner(this);
         }
 
         private IDictionary<string, string> ToStringDictionaryInner(object target = null)

--- a/src/Eshopworld.Core/BaseEvent.cs
+++ b/src/Eshopworld.Core/BaseEvent.cs
@@ -35,24 +35,18 @@
 
             try
             {
-                return FullFlow();
+                return JsonConvert.DeserializeObject<Dictionary<string, string>>(JsonConvert.SerializeObject(target));
             }
             catch (Exception)
             {
-                return ShallowFlow();
-            }
-
-            IDictionary<string, string> FullFlow() =>
-                JsonConvert.DeserializeObject<Dictionary<string, string>>(JsonConvert.SerializeObject(target));
-
-            IDictionary<string, string> ShallowFlow() =>
-                JsonConvert.DeserializeObject<Dictionary<string, string>>(
+                return JsonConvert.DeserializeObject<Dictionary<string, string>>(
                     JsonConvert.SerializeObject(target, new JsonSerializerSettings
                     {
                         ContractResolver = new NoReferencesJsonContractResolver(),
                         PreserveReferencesHandling = PreserveReferencesHandling.None,
                         ReferenceLoopHandling = ReferenceLoopHandling.Ignore
                     }));
+            }
         }
         /// <summary>
         /// Converts this POCO to a <see cref="IDictionary{TKey,TValue}"/> by using JSonConvert twice (both directions).

--- a/src/Eshopworld.Core/BaseEvent.cs
+++ b/src/Eshopworld.Core/BaseEvent.cs
@@ -1,6 +1,7 @@
 ﻿namespace Eshopworld.Core
 {
     using System;
+    using System.Linq;
     using System.Collections.Generic;
     using JetBrains.Annotations;
     using Newtonsoft.Json;
@@ -21,6 +22,38 @@
         {
         }
 
+
+        internal  IDictionary<string, string> ToUnionStringDictionary(object adjunctObject)
+        {
+            return ToStringDictionaryInner(this).Union(ToStringDictionaryInner(adjunctObject))
+                .ToDictionary(k => k.Key, v => v.Value);
+        }
+
+        private IDictionary<string, string> ToStringDictionaryInner(object target = null)
+        {
+            target = target ?? this;
+
+            try
+            {
+                return FullFlow();
+            }
+            catch (Exception)
+            {
+                return ShallowFlow();
+            }
+
+            IDictionary<string, string> FullFlow() =>
+                JsonConvert.DeserializeObject<Dictionary<string, string>>(JsonConvert.SerializeObject(target));
+
+            IDictionary<string, string> ShallowFlow() =>
+                JsonConvert.DeserializeObject<Dictionary<string, string>>(
+                    JsonConvert.SerializeObject(target, new JsonSerializerSettings
+                    {
+                        ContractResolver = new NoReferencesJsonContractResolver(),
+                        PreserveReferencesHandling = PreserveReferencesHandling.None,
+                        ReferenceLoopHandling = ReferenceLoopHandling.Ignore
+                    }));
+        }
         /// <summary>
         /// Converts this POCO to a <see cref="IDictionary{TKey,TValue}"/> by using JSonConvert twice (both directions).
         /// </summary>
@@ -28,20 +61,7 @@
         [NotNull]
         internal virtual IDictionary<string, string> ToStringDictionary()
         {
-            try
-            {
-                return JsonConvert.DeserializeObject<Dictionary<string, string>>(JsonConvert.SerializeObject(this));
-            }
-            catch (Exception)
-            {
-                return JsonConvert.DeserializeObject<Dictionary<string, string>>(
-                    JsonConvert.SerializeObject(this, new JsonSerializerSettings
-                    {
-                        ContractResolver = new NoReferencesJsonContractResolver(),
-                        PreserveReferencesHandling = PreserveReferencesHandling.None,
-                        ReferenceLoopHandling = ReferenceLoopHandling.Ignore
-                    }));
-            }
+            return ToStringDictionaryInner(this);
         }
 
         /// <summary>

--- a/src/Eshopworld.Core/Eshopworld.Core.csproj
+++ b/src/Eshopworld.Core/Eshopworld.Core.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
 
-    <Version>2.1.2</Version>
-    <PackageReleaseNotes>add dns configuration cascade interface</PackageReleaseNotes>
+    <Version>2.1.3</Version>
+    <PackageReleaseNotes>refactoring to fix custom exception properties not tracked as custom dimensions</PackageReleaseNotes>
 
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>

--- a/src/Eshopworld.Core/ExceptionEvent.cs
+++ b/src/Eshopworld.Core/ExceptionEvent.cs
@@ -1,6 +1,7 @@
 ﻿namespace Eshopworld.Core
 {
     using System;
+    using System.Collections.Generic;
     using JetBrains.Annotations;
     using Newtonsoft.Json;
 
@@ -27,10 +28,15 @@
 
         /// <summary>
         /// Specifies whether stack trace of exception should be simplified, e.g. by removing
-        /// references to compiler gerated methods.
+        /// references to compiler generated methods.
         /// </summary>
         [JsonIgnore]
         public virtual bool SimplifyStackTrace => true;
+
+        internal override IDictionary<string, string> ToStringDictionary()
+        {
+            return ToUnionStringDictionary(Exception);
+        }
     }
 
     /// <summary>

--- a/src/Tests/Eshopworld.Core.Tests/ExceptionEventTest.cs
+++ b/src/Tests/Eshopworld.Core.Tests/ExceptionEventTest.cs
@@ -50,7 +50,34 @@ public class ExceptionEventTest
             dict.ContainsKey(nameof(AnonymousTelemetryEvent.CallerLineNumber)).Should().BeTrue();
         }
 
-        public class CustomTestException : Exception
+
+        [Fact, IsUnit]
+        public void Test_ExceptionCustomProperties_AdjunctObjectThrows()
+        {
+            var exc = new ExceptionThrowingTestException{ CustomString = "blah" };
+
+            var bbEvent = exc.ToExceptionEvent();
+
+            var dict = bbEvent.ToStringDictionary();
+            dict.Should().NotContainKey(nameof(ExceptionThrowingTestException.CustomString));
+            dict.ContainsKey(nameof(AnonymousTelemetryEvent.CallerMemberName)).Should().BeTrue();
+            dict.ContainsKey(nameof(AnonymousTelemetryEvent.CallerFilePath)).Should().BeTrue();
+            dict.ContainsKey(nameof(AnonymousTelemetryEvent.CallerLineNumber)).Should().BeTrue();
+        }
+
+        public class ExceptionThrowingTestException : Exception
+        {
+            public string CustomString
+            {
+                get => throw new Exception();
+                // ReSharper disable once ValueParameterNotUsed
+                set
+                {
+                }
+            }
+        }
+
+        private class CustomTestException : Exception
         {
             public string CustomString { get; set; }
             public byte CustomByte { get; set; }

--- a/src/Tests/Eshopworld.Core.Tests/ExceptionEventTest.cs
+++ b/src/Tests/Eshopworld.Core.Tests/ExceptionEventTest.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Globalization;
+using System.Net;
 using Eshopworld.Core;
 using Eshopworld.Tests.Core;
 using FluentAssertions;
@@ -28,6 +30,31 @@ public class ExceptionEventTest
             var bbEvent = exception.ToExceptionEvent();
 
             bbEvent.Exception.Message.Should().Be(exceptionMessage);
+        }
+
+        [Fact, IsUnit]
+        public void Test_ExceptionCustomProperties()
+        {
+            var exc = new CustomTestException
+                {CustomByte = 123, CustomEnum = HttpStatusCode.Accepted, CustomString = "blah"};
+
+            var bbEvent = exc.ToExceptionEvent();
+
+            var dict = bbEvent.ToStringDictionary();
+            dict[nameof(CustomTestException.CustomString)].Should().Be("blah");
+            dict[nameof(CustomTestException.CustomByte)].Should().Be(123.ToString());
+            dict[nameof(CustomTestException.CustomEnum)].Should()
+                .Be(((int) HttpStatusCode.Accepted).ToString());
+            dict.ContainsKey(nameof(AnonymousTelemetryEvent.CallerMemberName)).Should().BeTrue();
+            dict.ContainsKey(nameof(AnonymousTelemetryEvent.CallerFilePath)).Should().BeTrue();
+            dict.ContainsKey(nameof(AnonymousTelemetryEvent.CallerLineNumber)).Should().BeTrue();
+        }
+
+        public class CustomTestException : Exception
+        {
+            public string CustomString { get; set; }
+            public byte CustomByte { get; set; }
+            public HttpStatusCode CustomEnum { get; set; }
         }
     }
 }


### PR DESCRIPTION
this refactors how side objects (adjunct objects) are added as custom properties

one thing I would note is that we probably should extricate event objects (BaseEvent etc.) from core... @djfr what was the reason for adding them here .. I could see perhaps Domain event base class to sit at core but even that may be questionable (the use case perhaps being model project defining domain events without direct linkage to BB, which would be added at the level where the events are actually published i.e. the main service)