### PR TITLE
Version bumped

### DIFF
--- a/src/Eshopworld.Core/Eshopworld.Core.csproj
+++ b/src/Eshopworld.Core/Eshopworld.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 
-    <Version>4.1.3</Version>
+    <Version>4.1.4</Version>
     <PackageReleaseNotes>Upgrade of dependencies.</PackageReleaseNotes>
 
     <TargetFramework>netstandard2.1</TargetFramework>


### PR DESCRIPTION
Version 4.1.3 has been uploaded to Nuget but release itself failed and it's not possible to reupload it again due to version conflict.
So version must be bumped to allow us to push package to NuGet again. 